### PR TITLE
feat: signIn post axios 요청기능 추가

### DIFF
--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -2,6 +2,8 @@ import { FormEvent } from 'react';
 import useInput from '../../hooks/useInput';
 import { SignContainer } from './SignIn.styled';
 import { useNavigate } from 'react-router-dom';
+import { signIn } from '../../services/todoInstance';
+import { AxiosError } from 'axios';
 
 export default function SignIn() {
   const [email, setEmail, onChangeEmail, validatedByEmail] = useInput('', 'email');
@@ -16,6 +18,22 @@ export default function SignIn() {
 
   const handleSignInSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    try {
+      const response = await signIn(email, password);
+      console.log(response);
+      if (response.status === 200) {
+        alert('로그인에 성공했습니다. \n투두리스트 화면으로 이동합니다.');
+        localStorage.setItem('access_token', response.data.access_token);
+        navigate('/todo');
+      } else {
+        alert(response);
+      }
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      console.log(axiosError.response?.data);
+      setEmail('');
+      setPassword('');
+    }
   };
 
   return (

--- a/src/services/todoInstance.ts
+++ b/src/services/todoInstance.ts
@@ -30,3 +30,7 @@ export function updateTodo(id: number, todo: string, isCompleted: boolean) {
 export function deleteTodo(id: number) {
   return todoInstance.delete(`/todos/${id}`).then((res) => res.data);
 }
+
+export function signIn(email: string, password: string) {
+  return todoInstance.post('/auth/signin', { email, password });
+}


### PR DESCRIPTION
## 관련 문서

만약 이 방식이 차용이 된다면
todoInstance의 이름을 apiInstance로 바꾸었으면 하는 희망이 있습니다.(아래 링크)
[이슈링크](https://github.com/wanted-pre-onboarding-12th-team-5/pre-onboarding-12th-1-5/issues/7)

## 변경사항:
로그인 axios post api 추가

## 확인할 목록:
로그인 완료 후 /todo로 네비게이션 정상작동 확인 및 로컬 스토리지에 'access_token' 키값으로 생성 확인
